### PR TITLE
Fix LDAP

### DIFF
--- a/core/infrastructure/src/main/java/org/hesperides/core/infrastructure/security/LdapConfiguration.java
+++ b/core/infrastructure/src/main/java/org/hesperides/core/infrastructure/security/LdapConfiguration.java
@@ -24,6 +24,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Profile;
+import org.springframework.ldap.support.LdapEncoder;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.annotation.Validated;
 
@@ -63,6 +64,6 @@ public class LdapConfiguration {
     private String techGroupDN;
 
     public String getSearchFilterForCN(String username) {
-        return String.format("(%s=%s)", usernameAttribute, username);
+        return String.format("(%s=%s)", usernameAttribute, LdapEncoder.nameEncode(username));
     }
 }

--- a/core/infrastructure/src/main/java/org/hesperides/core/infrastructure/security/groups/LdapSearchContext.java
+++ b/core/infrastructure/src/main/java/org/hesperides/core/infrastructure/security/groups/LdapSearchContext.java
@@ -15,6 +15,7 @@ import org.springframework.context.support.MessageSourceAccessor;
 import org.springframework.dao.IncorrectResultSizeDataAccessException;
 import org.springframework.ldap.core.DirContextOperations;
 import org.springframework.ldap.core.support.DefaultDirObjectFactory;
+import org.springframework.ldap.support.LdapEncoder;
 import org.springframework.ldap.support.LdapUtils;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.SpringSecurityMessageSource;
@@ -180,7 +181,7 @@ public class LdapSearchContext implements ParentGroupsDNRetriever {
         searchControls.setSearchScope(SearchControls.SUBTREE_SCOPE);
         try {
             // Durant cet appel, SpringSecurityLdapTemplate logue parfois des "Ignoring PartialResultException"
-            return SpringSecurityLdapTemplate.searchForSingleEntryInternal(dirContext, searchControls, base, searchFilter, new Object[]{cn});
+            return SpringSecurityLdapTemplate.searchForSingleEntryInternal(dirContext, searchControls, base, searchFilter, new Object[]{LdapEncoder.nameEncode(cn)});
         } catch (NamingException exception) {
             throw LdapUtils.convertLdapException(exception);
         }
@@ -190,7 +191,7 @@ public class LdapSearchContext implements ParentGroupsDNRetriever {
      * Retourne le DN amputé de son CN
      */
     private static String getBaseFrom(String cn, String dn) {
-        return dn.substring(("cn" + cn + ",").length() + 1);
+        return dn.substring(("cn=" + LdapEncoder.nameEncode(cn) + ",").length());
     }
 
     public static HashSet<String> extractDirectParentGroupDNs(Attributes attributes) {

--- a/tests/activedirectory-integration/pom.xml
+++ b/tests/activedirectory-integration/pom.xml
@@ -130,6 +130,27 @@
                     <useDefaultDelimiters>false</useDefaultDelimiters>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <skipIfEmpty>true</skipIfEmpty>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-install-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/tests/bdd/src/test/resources/authorizations/get-user-authorities.feature
+++ b/tests/bdd/src/test/resources/authorizations/get-user-authorities.feature
@@ -14,6 +14,7 @@ Feature: Get user authorities
     Then ABC_PROD_USER is listed under the user authority roles
 
   #issue-667
+  @require-user-without-group
   Scenario: retrieve a user that has no authorities
     Given a user that does not belong to any group
     When I get the current user information


### PR DESCRIPTION
Corrige un problème de requête LDAP lors de l'utilisation de groupes avec des caractères incompatibles LDAP non échappés.

Exemple :

```
o.h.c.i.s.groups.LdapSearchContext       : Retries exhausted while requesting LDAP for CN=Tests (Hesperides, & co)_b43e0afd32a0

org.springframework.ldap.BadLdapGrammarException: Failed to parse DN; nested exception is org.springframework.ldap.core.ParseException: Encountered " "," ", "" at line 1, column 1.
Was expecting one of:
    <ATTRIBUTE_TYPE_STRING> ...
    <LDAP_OID> ...
    " " ...
    
	at org.springframework.ldap.core.DistinguishedName.parse(DistinguishedName.java:229)
	at org.springframework.ldap.core.DistinguishedName.<init>(DistinguishedName.java:182)
	at org.springframework.security.ldap.SpringSecurityLdapTemplate.searchForSingleEntryInternal(SpringSecurityLdapTemplate.java:270)
	at org.hesperides.core.infrastructure.security.groups.LdapSearchContext.searchCN(LdapSearchContext.java:183)
```